### PR TITLE
Add LDFLAGS declaration to Linux section of GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,6 +27,7 @@ ifeq ($(shell uname), Linux)
 # Compiling on Linux.
 LIBBSD	 = -lbsd
 CFLAGS	+= -I/usr/local/include/libressl
+LDFLAGS += -L/usr/local/lib
 OBJS	+= util-portable.o \
 	   sandbox-null.o
 else ifeq ($(shell uname), Darwin)


### PR DESCRIPTION
LDFLAGS seem to be missing from the Linux (`ifeq ($(shell uname), Linux)`)section, causing a linking failure.

Adding this line fixed it for me.
