### PR TITLE
Support musl libc without libbsd

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,11 @@ OBJS 	 = acctproc.o \
 
 ifeq ($(shell uname), Linux)
 # Compiling on Linux.
+ifeq ($(shell $(CC) -dM -E - < /dev/null | grep __GLIBC__),__GLIBC__)
+# require libbsd for GNU libc, but not for musl libc
+CFLAGS  += -DHAVE_LIBBSD
 LIBBSD	 = -lbsd
+endif
 CFLAGS	+= -I/usr/local/include/libressl
 LDFLAGS += -L/usr/local/lib
 OBJS	+= util-portable.o \

--- a/config.h
+++ b/config.h
@@ -17,8 +17,21 @@
  */
 #ifdef __linux__
 # define _GNU_SOURCE
-# include <bsd/stdlib.h>
-# include <bsd/string.h>
+# ifdef HAVE_LIBBSD
+#  include <bsd/stdlib.h>
+#  include <bsd/string.h>
+# else
+#  ifndef __BEGIN_DECLS
+#   define __BEGIN_DECLS
+#  endif
+#  ifndef __END_DECLS
+#   define __END_DECLS
+#  endif
+#  include <errno.h>
+   static inline const char *getprogname() {
+	return program_invocation_short_name;
+   }
+# endif
 # include <grp.h>
 #endif
 
@@ -41,3 +54,4 @@ int	setresuid(gid_t, gid_t, gid_t);
 #include <netinet/in.h>
 #include <resolv.h>
 #endif
+

--- a/extern.h
+++ b/extern.h
@@ -17,6 +17,8 @@
 #ifndef EXTERN_H
 #define EXTERN_H
 
+#include <unistd.h> /* for pid_t */
+
 #ifndef PATH_VAR_EMPTY
 #define	PATH_VAR_EMPTY "/var/empty"
 #endif


### PR DESCRIPTION
libbsd is not very portable and does not work with musl libc on arm.
Only require libbsd with GNU libc.
