### PR TITLE
updated agreement URL

### DIFF
--- a/main.c
+++ b/main.c
@@ -33,7 +33,7 @@
 #include "extern.h"
 
 #define URL_AGREE "https://letsencrypt.org" \
-		  "/documents/LE-SA-v1.1.1-August-1-2016.pdf"
+		  "/documents/LE-SA-v1.2-November-15-2017.pdf"
 #define SSL_DIR "/etc/ssl/acme"
 #define SSL_PRIV_DIR "/etc/ssl/acme/private"
 #define ETC_DIR "/etc/acme"


### PR DESCRIPTION
The current version is outdated, since the URL is provided by the acme protocol now and it has changed since this client was last updated.